### PR TITLE
fix mysql varchar limit

### DIFF
--- a/metl/field.py
+++ b/metl/field.py
@@ -25,12 +25,13 @@ from metl.exception import *
 class Field( object ):
 
     # void
-    def __init__( self, field_name, field_type, field_final_type = None, key = False, defaultValue = None, transforms = None ):
+    def __init__( self, field_name, field_type, field_final_type = None, key = False, defaultValue = None, transforms = None, limit = None ):
 
         self.field_name       = field_name
         self.orig_type        = field_type
         self.field_type       = field_type
         self.field_final_type = field_final_type or field_type
+        self.limit            = limit
         self.value            = None
         self.transforms       = transforms
         self.key              = key
@@ -47,7 +48,8 @@ class Field( object ):
             self.getFinalType().clone(),
             key = self.isKey(),
             defaultValue = self.getDefaultValue(),
-            transforms = self.getTransforms()
+            transforms = self.getTransforms(),
+            limit = self.limit
         )
 
     def getDefaultValue( self ):
@@ -76,6 +78,10 @@ class Field( object ):
     def getType( self ):
 
         return self.field_type
+
+    def getLimit( self ):
+
+        return self.limit
 
     # bool
     def isConvertable( self, field_type ):
@@ -132,6 +138,10 @@ class Field( object ):
         elif hard:
             self.field_type = field_type
             self.value      = None
+
+    def setLimit( self, limit ):
+
+      self.limit = limit
 
     # void
     def setName( self, field_name ):

--- a/tests/config/test_db_target_mysql_varchar.yml
+++ b/tests/config/test_db_target_mysql_varchar.yml
@@ -1,0 +1,19 @@
+base: tests/config/test_basic_target.yml
+
+source:
+  fields:
+    - name: id
+      type: Integer
+      key: true
+    - name: name
+      type: String
+    - name: name_limited
+      type: String
+      limit: 130
+
+target:
+  type: Database
+  url: mysql://user:pass@host:port/database
+  table: result
+  addIDKey: false
+  createTable: true

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -53,6 +53,10 @@ class Test_Field( unittest.TestCase ):
 
         self.assertTrue( self.field.isKey() )
 
+    def test_key( self ):
+
+        self.assertTrue( self.field.isKey() )
+
     def test_value( self ):
 
         self.assertEqual( self.field.getValue(), self.defaultValue )
@@ -72,6 +76,12 @@ class Test_Field( unittest.TestCase ):
         self.assertEqual( self.field.getType(), self.startType )
         self.field.run()
         self.assertEqual( self.field.getType(), self.endType )
+
+    def test_limit( self ):
+
+        self.assertEqual( self.field.getLimit(), None )
+        self.field.setLimit( 100 )
+        self.assertEqual( self.field.getLimit(), 100 )
 
     def test_fieldtype_value( self ):
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -143,5 +143,23 @@ class Test_Target( unittest.TestCase ):
 
         os.unlink( 'tests/target' )
 
+    def test_db_target_mysql_varchar( self ):
+
+        configparser = ConfigParser( Config( 'tests/config/test_db_target_mysql_varchar.yml' ) )
+        target = configparser.getTarget()
+        dburl = target.url
+        target.url = 'sqlite:///'
+        target.initialize()
+
+        self.assertTrue( target.db_table.c.name.type.length is None )
+        self.assertEquals( 130, target.db_table.c.name_limited.type.length )
+
+        target.url = dburl
+        target.getTable( False ).drop( target.db_connection )
+        table = target.getCreatedTable()
+
+        self.assertEquals( 255, target.db_table.c.name.type.length )
+        self.assertEquals( 130, target.db_table.c.name_limited.type.length )
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi again,

While trying to target mysql, I faced a problem at the table creation. In fact mysql needs a length for varchars.

So I tried to slip a limit into config files and an autolimit for varchars on mysql targets, I added some tests too.

I just draw your attention on the fact that the test are not similar to the previously done tests, and are tweaking around a little, so if you see a better to do this, I'm all ears ;-)

Cheers!
