### PR TITLE
Fixed typographical error, changed arbitary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,7 +754,7 @@ An example of a YAML configuration:
 
 Source type mainly used for testing, in which the configuration file contains the records. Has only one parameter:
 
-- **sourceRecords**: List of data in arbitary order.
+- **sourceRecords**: List of data in arbitrary order.
 
 Example from above:
 


### PR DESCRIPTION
@ceumicrodata, I've corrected a typographical error in the documentation of the [mETL](https://github.com/ceumicrodata/mETL) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.